### PR TITLE
Enable Ollama API and improve message handling

### DIFF
--- a/config/client_config.yaml
+++ b/config/client_config.yaml
@@ -37,7 +37,7 @@ response:
   enabled: true              # Enable/disable sending responses back
   max_length: 500           # Maximum response length to send
   prefix: "AI: "            # Prefix for responses
-  suffix: "\n---\n"         # Suffix to mark end of response
+  suffix: "<<<END>>>"       # Unique suffix to mark end of response
   
 # Test mode configuration
 test:

--- a/config/client_config.yaml
+++ b/config/client_config.yaml
@@ -9,7 +9,7 @@ serial:
 
 tinyllm:
   # TinyLLM configuration - use "mock" for testing, "api" for Raspberry Pi
-  interface_type: "mock"  # Use "api" for Raspberry Pi with Ollama
+  interface_type: "api"  # Use "api" for Raspberry Pi with Ollama
   api_endpoint: "http://localhost:11434/api/generate"
   headers:
     Content-Type: "application/json"

--- a/main.py
+++ b/main.py
@@ -120,7 +120,7 @@ class TinyLLMSerialClient:
             if (sent_msg in received_clean or 
                 received_clean in sent_msg or
                 received_clean.startswith("AI:") or  # Our response prefix
-                received_clean == "---"):  # Our response suffix
+                "<<<END>>>" in received_clean):  # Our response suffix
                 
                 time_diff = (now - sent_time).total_seconds()
                 log_process_event(self.logger, 
@@ -196,8 +196,9 @@ class TinyLLMSerialClient:
         if len(response) > max_length - len(prefix) - len(suffix):
             response = response[:max_length - len(prefix) - len(suffix) - 3] + "..."
             
-        # Format final message
-        formatted_response = f"{prefix}{response}{suffix}"
+        # Format final message with clear terminator
+        # Add a special end-of-message marker that ARM can detect
+        formatted_response = f"{prefix}{response}\n{suffix}"
         
         # Track sent message for echo detection
         self.sent_messages.append((datetime.now(), formatted_response.strip()))

--- a/src/serial_client.py
+++ b/src/serial_client.py
@@ -217,7 +217,15 @@ class SerialClient:
             if not message.endswith('\n'):
                 message += '\n'
                 
-            self.port.write(message.encode('ascii'))
+            # Send in smaller chunks to avoid buffer overflow
+            chunk_size = 64  # Safe size for most serial buffers
+            message_bytes = message.encode('ascii')
+            
+            for i in range(0, len(message_bytes), chunk_size):
+                chunk = message_bytes[i:i+chunk_size]
+                self.port.write(chunk)
+                time.sleep(0.01)  # Small delay between chunks
+                
             self.logger.debug(f"Sent message: '{message.strip()}'")
             return True
             


### PR DESCRIPTION
## Summary
- Enable real LLM responses via Ollama API
- Improve serial message handling for long responses
- Update message terminator for reliable message boundaries

## Changes

### 1. Enable Ollama API (`config/client_config.yaml`)
- Changed `interface_type` from "mock" to "api"
- System now uses TinyLlama via Ollama for real AI responses
- Replaces generic mock messages with actual AI-generated content

### 2. Improve Serial Communication (`src/serial_client.py`)
- Implement chunked sending (64-byte chunks) to prevent buffer overflow
- Add small delays between chunks for reliability
- Prevents long messages from being split incorrectly

### 3. Update Message Format
- Changed terminator from `---` to `<<<END>>>` for clearer message boundaries
- Updated echo detection to recognize new terminator
- Message format is now:
  ```
  AI: [response text]
  <<<END>>>
  ```

## Testing
- Tested with real Ollama/TinyLlama responses
- Verified chunked sending works with long messages
- Confirmed echo detection still filters hardware loopback

## Notes for ARM Team
The ARM assembly code should be updated to:
1. Buffer incoming serial data until `<<<END>>>` is received
2. Process the complete message between `AI: ` and `<<<END>>>`
3. This ensures complete AI responses are received as single messages

## Prerequisites
- Ollama must be installed and running
- TinyLlama model must be available (`ollama pull tinyllama`)
- Update ARM code to handle new message format

Closes #2